### PR TITLE
Add /usr/sbin/ to PATH to find networksetup binary

### DIFF
--- a/etc/openvpn/update-resolv-conf
+++ b/etc/openvpn/update-resolv-conf
@@ -13,6 +13,7 @@
 [ "$script_type" ] || exit 0
 [ "$dev" ] || exit 0
 
+PATH=$PATH:/usr/sbin/
 NMSRVRS=()
 SRCHS=()
 adapters=()


### PR DESCRIPTION
I get `networksetup: command not found` out of the box, adding `/usr/sbin/` to path fixes it.